### PR TITLE
Handles version file name change

### DIFF
--- a/lib/action.rb
+++ b/lib/action.rb
@@ -39,11 +39,19 @@ class Action
   end
 
   def version_increased?(branch_name:, trunk_name: 'master')
-    branch_version = fetch_version(ref: branch_name)
+    branch_version = nil
+    begin
+      branch_version = fetch_version(ref: branch_name)
+    rescue Octokit::NotFound
+    end
     trunk_version = fetch_version(ref: trunk_name)
-    puts "branch version: #{branch_version}"
+    if branch_version
+      puts "branch version: #{branch_version}"
+    else
+      puts "branch version: file not found, presumed name changed"
+    end
     puts "trunk version: #{trunk_version}"
-    branch_version > trunk_version
+    branch_version == nil || branch_version > trunk_version
   end
 
   private

--- a/lib/action.rb
+++ b/lib/action.rb
@@ -39,19 +39,12 @@ class Action
   end
 
   def version_increased?(branch_name:, trunk_name: 'master')
-    branch_version = nil
-    begin
-      branch_version = fetch_version(ref: branch_name)
-    rescue Octokit::NotFound
-    end
+    branch_version = fetch_version_safe(ref: branch_name)
     trunk_version = fetch_version(ref: trunk_name)
-    if branch_version
-      puts "branch version: #{branch_version}"
-    else
-      puts "branch version: file not found, presumed name changed"
-    end
+    puts branch_version ? "branch version: #{branch_version}" : 'branch version: file not found, presumed name changed'
     puts "trunk version: #{trunk_version}"
-    branch_version == nil || branch_version > trunk_version
+
+    branch_version.nil? || branch_version > trunk_version
   end
 
   private
@@ -61,6 +54,12 @@ class Action
     match = content.match(GEMSPEC_VERSION) || content.match(SEMVER_VERSION)
 
     format_version(match)
+  end
+
+  def fetch_version_safe(ref:)
+    fetch_version(ref: ref)
+  rescue Octokit::NotFound
+    nil
   end
 
   def format_version(version)

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -115,7 +115,7 @@ describe Action do # rubocop: disable Metrics/BlockLength
     end
 
     context 'when version file not found' do
-      it 'fails when version file not found' do
+      it 'raises exception' do
         mock_version_response_error('master')
         mock_version_response('my_branch', '1.2.3')
 

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -78,7 +78,7 @@ describe Action do # rubocop: disable Metrics/BlockLength
     end
   end
 
-  describe '#version_increased?' do
+  describe '#version_increased?' do # rubocop:disable Metrics/BlockLength
     RSpec.shared_examples 'version_increased? for all supported file types' do |new_version, result|
       context 'when the content is a version file' do
         it 'returns false if the versions match' do

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -33,7 +33,7 @@ describe Action do # rubocop: disable Metrics/BlockLength
       action.check_version
     end
 
-    it 'creates a failure state when version is changed' do
+    it 'creates a failure state when version is not changed' do
       allow(action).to receive(:version_changed?).and_return(false)
       expect(client).to receive(:create_status).with('simplybusiness/test',
                                                      '1111',
@@ -104,6 +104,24 @@ describe Action do # rubocop: disable Metrics/BlockLength
     it_behaves_like 'version_increased? for all supported file types', '1.2.4', true
     it_behaves_like 'version_increased? for all supported file types', '1.3.0', true
     it_behaves_like 'version_increased? for all supported file types', '2.0.0', true
+
+    context 'when version file name has changed so old version file not found' do
+      it 'returns true if old version file not found' do
+        mock_version_response('master', '1.2.3')
+        mock_version_response_error('my_branch')
+
+        expect(action.version_increased?(branch_name: 'my_branch')).to eq(true)
+      end
+    end
+
+    context 'when version file not found' do
+      it 'fails when version file not found' do
+        mock_version_response_error('master')
+        mock_version_response('my_branch', '1.2.3')
+
+        expect { action.version_increased?(branch_name: 'my_branch') }.to raise_error(Octokit::NotFound)
+      end
+    end
   end
 
   private
@@ -136,5 +154,11 @@ describe Action do # rubocop: disable Metrics/BlockLength
     allow(client).to receive(:contents)
       .with('simplybusiness/test', path: 'version.rb', query: { ref: branch })
       .and_return(content)
+  end
+
+  def mock_version_response_error(branch)
+    allow(client).to receive(:contents)
+      .with('simplybusiness/test', path: 'version.rb', query: { ref: branch })
+      .and_raise(Octokit::NotFound)
   end
 end

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -106,7 +106,7 @@ describe Action do # rubocop: disable Metrics/BlockLength
     it_behaves_like 'version_increased? for all supported file types', '2.0.0', true
 
     context 'when version file name has changed so old version file not found' do
-      it 'returns true if old version file not found' do
+      it 'returns true' do
         mock_version_response('master', '1.2.3')
         mock_version_response_error('my_branch')
 


### PR DESCRIPTION
If the version file name has been changed, the old version will not be detected. This change ensures that the check will pass because otherwise the check has to be disabled in order to merge the change.

Also adds test for case demonstrating what happens when version file name is misconfigured.