### PR TITLE
Create failed status when version file not found

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*.rb

--- a/lib/action.rb
+++ b/lib/action.rb
@@ -65,7 +65,8 @@ class Action
   def fetch_version_safe(ref:)
     fetch_version(ref: ref)
   rescue Octokit::NotFound
-    nil
+    description = "Version file not found #{file_path}"
+    client.create_status(repo, head_commit, 'failure', description: description, context: 'Gem Version')
   end
 
   def format_version(version)

--- a/lib/action.rb
+++ b/lib/action.rb
@@ -46,8 +46,8 @@ class Action
 
   def version_increased?(branch_name:, trunk_name: 'master')
     branch_version = fetch_version_safe(ref: branch_name)
-    trunk_version = fetch_version(ref: trunk_name)
-    puts branch_version ? "branch version: #{branch_version}" : 'branch version: file not found, presumed name changed'
+    trunk_version = fetch_version_safe(ref: trunk_name)
+    puts "branch version: #{branch_version}"
     puts "trunk version: #{trunk_version}"
 
     branch_version.nil? || branch_version > trunk_version

--- a/lib/action.rb
+++ b/lib/action.rb
@@ -18,7 +18,7 @@ class Action
   end
 
   def check_version
-    if version_changed?
+    if version_increased?(branch_name: head_branch, trunk_name: base_branch)
       state = 'success'
       description = 'Updated'
     else
@@ -33,15 +33,6 @@ class Action
     text = failed_description || "Update: #{file_path}"
     text = text[0...137] + '...' unless text.length <= 140
     text
-  end
-
-  def version_changed?
-    version_file_changed?(pull_number) && version_increased?(branch_name: head_branch, trunk_name: base_branch)
-  end
-
-  def version_file_changed?(pull_number)
-    file_changed = client.pull_request_files(repo, pull_number).map { |res| res[:filename] }
-    file_changed.include?(file_path)
   end
 
   def version_increased?(branch_name:, trunk_name: 'master')

--- a/lib/action.rb
+++ b/lib/action.rb
@@ -66,7 +66,7 @@ class Action
   def fetch_version_safe(ref:)
     fetch_version(ref: ref)
   rescue Octokit::NotFound
-    @failed_description = "Version file not found on #{file_path}"
+    @failed_description = "Version file not found on #{ref} branch #{file_path}"
     nil
   end
 

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -24,7 +24,7 @@ describe Action do
 
   describe '#check_version' do
     it 'creates a success state when version is changed' do
-      allow(action).to receive(:version_changed?).and_return(true)
+      allow(action).to receive(:version_increased?).and_return(true)
       expect(client).to receive(:create_status).with('simplybusiness/test',
                                                      '1111',
                                                      'success',
@@ -34,7 +34,7 @@ describe Action do
     end
 
     it 'creates a failure state when version is not changed' do
-      allow(action).to receive(:version_changed?).and_return(false)
+      allow(action).to receive(:version_increased?).and_return(false)
       expect(client).to receive(:create_status).with('simplybusiness/test',
                                                      '1111',
                                                      'failure',
@@ -44,7 +44,7 @@ describe Action do
     end
 
     it 'creates a failure state when version file is not found' do
-      allow(action).to receive(:version_changed?).and_return(false)
+      allow(action).to receive(:version_increased?).and_return(false)
       allow(action).to receive(:failed_description).and_return('Version file not found on version.rb')
       expect(client).to receive(:create_status).with('simplybusiness/test',
                                                      '1111',
@@ -52,40 +52,6 @@ describe Action do
                                                      context: 'Gem Version',
                                                      description: 'Version file not found on version.rb')
       action.check_version
-    end
-  end
-
-  describe '#version_changed?' do
-    it 'return false when version file not changed' do
-      allow(action).to receive(:version_file_changed?).and_return(false)
-      expect(action.version_changed?).to be false
-    end
-
-    it 'return false when version is not increased' do
-      allow(action).to receive(:version_file_changed?).and_return(true)
-      allow(action).to receive(:version_increased?).and_return(false)
-      expect(action.version_changed?).to be false
-    end
-
-    it 'return true when version file and version both changed' do
-      allow(action).to receive(:version_file_changed?).and_return(true)
-      allow(action).to receive(:version_increased?).and_return(true)
-      expect(action.version_changed?).to be true
-    end
-  end
-
-  describe '#version_file_changed?' do
-    it 'return true if the github API response includes a version file' do
-      allow(client).to receive(:pull_request_files).and_return([
-                                                                 { filename: 'version.rb' },
-                                                                 { filename: 'foo.txt' }
-                                                               ])
-      expect(action.version_file_changed?(1)).to be true
-    end
-
-    it 'return false if the github API response does not include a version file' do
-      allow(client).to receive(:pull_request_files).and_return([{ filename: 'foo.txt' }])
-      expect(action.version_file_changed?(1)).to be false
     end
   end
 

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -130,7 +130,7 @@ describe Action do # rubocop: disable Metrics/BlockLength
         mock_version_response('my_branch', '1.2.3')
 
         expect { action.version_increased?(branch_name: 'my_branch') }.to_not raise_error
-        expect(action.failed_description).to eq('Version file not found on version.rb')
+        expect(action.failed_description).to eq('Version file not found on master branch version.rb')
       end
     end
   end

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -3,7 +3,7 @@
 require 'ostruct'
 require_relative '../lib/action'
 
-describe Action do # rubocop: disable Metrics/BlockLength
+describe Action do
   let(:client) { instance_double(Octokit::Client) }
   let(:config) do
     OpenStruct.new(
@@ -89,7 +89,7 @@ describe Action do # rubocop: disable Metrics/BlockLength
     end
   end
 
-  describe '#version_increased?' do # rubocop:disable Metrics/BlockLength
+  describe '#version_increased?' do
     RSpec.shared_examples 'version_increased? for all supported file types' do |new_version, result|
       context 'when the content is a version file' do
         it 'returns false if the versions match' do

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -106,10 +106,14 @@ describe Action do # rubocop: disable Metrics/BlockLength
     it_behaves_like 'version_increased? for all supported file types', '2.0.0', true
 
     context 'when version file name has changed so old version file not found' do
-      it 'returns true' do
+      it 'create failure status with a description \' version file not found\'' do
         mock_version_response('master', '1.2.3')
         mock_version_response_error('my_branch')
-
+        expect(client).to receive(:create_status).with('simplybusiness/test',
+                                                       '1111',
+                                                       'failure',
+                                                       context: 'Gem Version',
+                                                       description: 'Version file not found version.rb')
         expect(action.version_increased?(branch_name: 'my_branch')).to eq(true)
       end
     end


### PR DESCRIPTION
## What

Create failed status when version file not found.

## Why

So we can display message in status check why the action is not able to compare files.
