### PR TITLE
Use the repo version and use cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,8 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.5
-      - name: Install dependencies
-        run: bundle install
+          ruby-version: .ruby-version
+          bundler-cache: true
       - name: Run rubocop
         run: bundle exec rubocop
       - name: Run test


### PR DESCRIPTION
Current CI is using Ruby 2.6 which is EoL, this should use the .ruby-version file.