### PR TITLE
Refactor testing

### DIFF
--- a/lib/action.rb
+++ b/lib/action.rb
@@ -32,6 +32,16 @@ class Action
     client.create_status(repo, head_commit, state, description: description, context: 'Version check')
   end
 
+  def fetch_version(ref:)
+    content = Base64.decode64(client.contents(repo, path: file_path, query: { ref: ref })['content'])
+    match = content.match(VERSION_SETTING)
+
+    format_version(match)
+  rescue Octokit::NotFound
+    @failed_description = "Version file not found on #{ref} branch #{file_path}"
+    nil
+  end
+
   def version_increased?(branch_name:, trunk_name: 'master')
     branch_version = fetch_version(ref: branch_name)
     trunk_version = fetch_version(ref: trunk_name)
@@ -43,16 +53,6 @@ class Action
   end
 
   private
-
-  def fetch_version(ref:)
-    content = Base64.decode64(client.contents(repo, path: file_path, query: { ref: ref })['content'])
-    match = content.match(VERSION_SETTING)
-
-    format_version(match)
-  rescue Octokit::NotFound
-    @failed_description = "Version file not found on #{ref} branch #{file_path}"
-    nil
-  end
 
   def format_version(version)
     Gem::Version.new(version[0].split(SEPARATOR).last.gsub(/\s/, '').gsub(/'|"/, ''))

--- a/lib/action.rb
+++ b/lib/action.rb
@@ -8,7 +8,7 @@ class Action
 
   SEMVER = /["']*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?["']*/ # rubocop:disable Layout/LineLength
   SEPARATOR = /\s*[:=]\s*/
-  VERSION_KEY = /(?:^|\.|\s|"|')version["']*/
+  VERSION_KEY = /(?:^|\.|\s|"|')(?:base|version)["']*/
   VERSION_SETTING = Regexp.new(VERSION_KEY.source + SEPARATOR.source + SEMVER.source, Regexp::IGNORECASE).freeze
 
   def initialize(config)

--- a/lib/action.rb
+++ b/lib/action.rb
@@ -33,8 +33,8 @@ class Action
   end
 
   def version_increased?(branch_name:, trunk_name: 'master')
-    branch_version = fetch_version_safe(ref: branch_name)
-    trunk_version = fetch_version_safe(ref: trunk_name)
+    branch_version = fetch_version(ref: branch_name)
+    trunk_version = fetch_version(ref: trunk_name)
     return false if branch_version.nil? || trunk_version.nil?
 
     puts "::notice title=Trunk version::trunk version: #{trunk_version}"
@@ -49,10 +49,6 @@ class Action
     match = content.match(VERSION_SETTING)
 
     format_version(match)
-  end
-
-  def fetch_version_safe(ref:)
-    fetch_version(ref: ref)
   rescue Octokit::NotFound
     @failed_description = "Version file not found on #{ref} branch #{file_path}"
     nil

--- a/lib/action.rb
+++ b/lib/action.rb
@@ -8,7 +8,7 @@ class Action
 
   SEMVER = /["']*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?["']*/ # rubocop:disable Layout/LineLength
   SEPARATOR = /\s*[:=]\s*/
-  VERSION_KEY = /(^|\.|\s)version/
+  VERSION_KEY = /(?:^|\.|\s|"|')version["']*/
   VERSION_SETTING = Regexp.new(VERSION_KEY.source + SEPARATOR.source + SEMVER.source, Regexp::IGNORECASE).freeze
 
   def initialize(config)

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -7,24 +7,27 @@ Config = Struct.new(:client, :file_path, :event_payload)
 
 describe Action do
   let(:client) { instance_double(Octokit::Client) }
-  let(:config) do
-    Config.new(
-      client,
-      'version.rb',
-      {
-        'repository' => { 'full_name' => 'simplybusiness/test' },
-        'pull_request' => {
-          'number' => 1,
-          'head' => { 'branch' => 'my_branch', 'sha' => '1111' },
-          'base' => { 'branch' => 'master' }
-        }
+  let(:event_payload) do
+    {
+      'repository' => { 'full_name' => 'simplybusiness/test' },
+      'pull_request' => {
+        'number' => 1,
+        'head' => { 'branch' => 'my_branch', 'sha' => '1111' },
+        'base' => { 'branch' => 'master' }
       }
-    )
+    }
   end
 
-  let(:action) { Action.new(config) }
-
   describe '#check_version' do
+    let(:config) do
+      Config.new(
+        client,
+        'version.rb',
+        event_payload
+      )
+    end
+    let(:action) { Action.new(config) }
+    
     it 'creates a success state when version is changed' do
       allow(action).to receive(:version_increased?).and_return(true)
       expect(client).to receive(:create_status).with(
@@ -66,6 +69,14 @@ describe Action do
   end
 
   describe '#fetch_version' do
+    let(:config) do
+      Config.new(
+        client,
+        'version.rb',
+        event_payload
+      )
+    end
+    let(:action) { Action.new(config) }
     let(:repo) { 'simplybusiness/test' }
     let(:file_path) { 'version.rb' }
     let(:ref) { 'my_branch' }
@@ -104,6 +115,15 @@ describe Action do
   end
 
   describe '#version_increased?' do
+    let(:config) do
+      Config.new(
+        client,
+        'version.rb',
+        event_payload
+      )
+    end
+    let(:action) { Action.new(config) }
+
     RSpec.shared_examples 'version_increased? for all supported file types' do |new_version, result|
       context 'when the content is a version file' do
         it 'returns false if the versions match' do
@@ -150,6 +170,15 @@ describe Action do
   end
 
   describe 'Message' do
+    let(:config) do
+      Config.new(
+        client,
+        'version.rb',
+        event_payload
+      )
+    end
+    let(:action) { Action.new(config) }
+
     it 'truncates to 140 characters if needed' do
       config.file_path = 'a/very/large/file/path/to/get/to/the/version/file/located/in/a/random/folder/somewhere/' \
                          'in/this/repo/oh/my/gosh/its/still/going/wherever/could/the/version/be/oh/found/it/version.rb'

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -115,6 +115,12 @@ describe Action do
       expect(action.fetch_version(ref: ref)).to eq("1.2.3")
     end
 
+    it 'returns the correct version for a sb algo-generated version.rb file' do
+      mock_response('my_branch', mock_sb_algo_version_content('1.2.3'))
+
+      expect(action.fetch_version(ref: ref)).to eq("1.2.3")
+    end
+
     it 'returns the correct version for a gemspec file' do
       mock_response('my_branch', mock_gemspec_content('1.2.3'))
 
@@ -244,6 +250,17 @@ describe Action do
     %(
       module TestRepo
         VERSION='#{version}'
+      end
+    )
+  end
+
+  def mock_sb_algo_version_content(version)
+    %(
+      module TestRepo
+        base = '#{version}'
+
+        # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
+        VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "\#{base}.\#{pre}"
       end
     )
   end

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -18,6 +18,26 @@ describe Action do
     }
   end
 
+  describe 'VERSION_SETTING' do
+    it 'matches correct version settings' do
+      expect(Action::VERSION_SETTING).to match('VERSION=1.2.3')
+      expect(Action::VERSION_SETTING).to match('version=1.2.3')
+      expect(Action::VERSION_SETTING).to match('Version=1.2.3')
+      expect(Action::VERSION_SETTING).to match('VERSION=1.2.3-alpha')
+      expect(Action::VERSION_SETTING).to match('VERSION=1.2.3+build123')
+      expect(Action::VERSION_SETTING).to match('VERSION = 1.2.3')
+      expect(Action::VERSION_SETTING).to match('"VERSION" = "1.2.3"')
+      expect(Action::VERSION_SETTING).to match("'VERSION' = '1.2.3'")
+      expect(Action::VERSION_SETTING).to match('"VERSION": "1.2.3"')
+      expect(Action::VERSION_SETTING).to match('gem.version = 1.2.3')
+    end
+
+    it 'does not match invalid version settings' do
+      expect(Action::VERSION_SETTING).not_to match('5.5.5')
+      expect(Action::VERSION_SETTING).not_to match('expected_ruby_version = 3.3.0')
+    end
+  end
+
   describe '#check_version' do
     let(:config) do
       Config.new(

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -20,7 +20,7 @@ describe Action do
   end
   let(:config) { Config.new(client, file_path, event_payload) }
   let(:action) { Action.new(config) }
-  let(:repo) { 'simplybusiness/test' }  
+  let(:repo) { 'simplybusiness/test' }
   let(:ref) { 'my_branch' }
 
   describe 'VERSION_SETTING' do
@@ -48,14 +48,14 @@ describe Action do
       expect(Action::VERSION_SETTING).to match('"VERSION": "1.2.3"')
     end
 
-    it 'handles version stored on object' do 
+    it 'handles version stored on object' do
       expect(Action::VERSION_SETTING).to match('gem.version = 1.2.3')
     end
 
     it 'does not match version number only' do
       expect(Action::VERSION_SETTING).not_to match('5.5.5')
     end
-    
+
     it 'does not match unrelated versioning' do
       expect(Action::VERSION_SETTING).not_to match('expected_ruby_version = 3.3.0')
     end
@@ -102,11 +102,10 @@ describe Action do
     end
   end
 
-  describe '#fetch_version' do   
-
+  describe '#fetch_version' do
     it 'returns the correct version for a version.rb file' do
       mock_response('my_branch', mock_version_content('1.2.3'))
-    
+
       expect(action.fetch_version(ref: ref)).to eq("1.2.3")
     end
 
@@ -145,12 +144,11 @@ describe Action do
   end
 
   describe '#version_increased?' do
-
     context 'when version is unchanged' do
-      it 'returns false' do      
+      it 'returns false' do
         mock_response('master', mock_version_content('1.2.3'))
         mock_response('my_branch', mock_version_content('1.2.3'))
-        
+
         expect(action.version_increased?(branch_name: 'my_branch')).to be(false)
       end
     end
@@ -173,20 +171,20 @@ describe Action do
       end
     end
 
-    context 'when there is a minor version increase' do 
+    context 'when there is a minor version increase' do
       it 'returns true' do
         mock_response('master', mock_version_content('1.2.3'))
         mock_response('my_branch', mock_version_content('1.3.0'))
-  
+
         expect(action.version_increased?(branch_name: 'my_branch')).to be(true)
       end
     end
 
-    context 'when there is a major version increase' do     
+    context 'when there is a major version increase' do
       it 'returns true' do
         mock_response('master', mock_version_content('1.2.3'))
         mock_response('my_branch', mock_version_content('2.0.0'))
-        
+
         expect(action.version_increased?(branch_name: 'my_branch')).to be(true)
       end
     end
@@ -212,8 +210,9 @@ describe Action do
 
   describe 'message' do
     it 'truncates to 140 characters if needed' do
-      config.file_path = 'a/very/large/file/path/to/get/to/the/version/file/located/in/a/random/folder/somewhere/' \
-                         'in/this/repo/oh/my/gosh/its/still/going/wherever/could/the/version/be/oh/found/it/version_file_path'
+      config.file_path = 'a/very/large/file/path/to/get/to/the/version/file/located/in/a/random/folder' \
+                         '/somewhere/in/this/repo/oh/my/gosh/its/still/going/wherever' \
+                         '/could/the/version/be/oh/found/it/version_file_path'
       message = "Update: #{config.file_path}"
       description = action.send(:truncate_message, message)
       expect(description.length).to eq(140)
@@ -253,7 +252,7 @@ describe Action do
     )
   end
 
-  def mock_package_json_content(version)
+  def mock_package_json_content(_version)
     %(
       {
         "name": "action-testing",
@@ -261,8 +260,8 @@ describe Action do
       }
     )
   end
-  
-  def mock_pyproject_toml_content(version)
+
+  def mock_pyproject_toml_content(_version)
     %(
       [tool.poetry]
       name = "action-testing"
@@ -273,7 +272,7 @@ describe Action do
   def mock_response(branch, content)
     allow(client).to receive(:contents)
       .with('simplybusiness/test', path: config.file_path, query: { ref: branch })
-      .and_return({'content' => Base64.encode64(content)})
+      .and_return({ 'content' => Base64.encode64(content) })
   end
 
   def mock_response_error(branch)

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -89,34 +89,160 @@ describe Action do
   end
 
   describe '#fetch_version' do
-    let(:config) do
-      Config.new(
-        client,
-        'version.rb',
-        event_payload
-      )
-    end
-    let(:action) { Action.new(config) }
-    let(:repo) { 'simplybusiness/test' }
-    let(:file_path) { 'version.rb' }
+    let(:repo) { 'simplybusiness/test' }  
     let(:ref) { 'my_branch' }
-    let(:content) { "module TestRepo\n  VERSION='1.2.3'\nend\n" }
     let(:decoded_content) { Base64.encode64(content) }
     let(:expected_version) { '1.2.3' }
 
-    before do
-      allow(client).to receive(:contents)
-        .with(repo, path: file_path, query: { ref: ref })
-        .and_return('content' => decoded_content)
+    context 'when the version file is a version.rb' do
+      let(:config) do
+        Config.new(
+          client,
+          'version.rb',
+          event_payload
+        )
+      end
+      let(:action) { Action.new(config) }
+      let(:file_path) { 'version.rb' }
+      let(:content) { "module TestRepo\n  VERSION='#{expected_version}'\nend\n" }
+
+      before do
+        allow(client).to receive(:contents)
+          .with(repo, path: file_path, query: { ref: ref })
+          .and_return('content' => decoded_content)
+      end
+
+      it 'returns the version' do
+        expect(action.fetch_version(ref: ref)).to eq(expected_version)
+      end
     end
 
-    context 'when the version file exists' do
+    context 'when the version file is a version.rb' do
+      let(:config) do
+        Config.new(
+          client,
+          'version.rb',
+          event_payload
+        )
+      end
+      let(:action) { Action.new(config) }
+      let(:file_path) { 'version.rb' }
+      let(:content) { "module TestRepo\n  VERSION='#{expected_version}'\nend\n" }
+
+      before do
+        allow(client).to receive(:contents)
+          .with(repo, path: file_path, query: { ref: ref })
+          .and_return('content' => decoded_content)
+      end
+
+      it 'returns the version' do
+        expect(action.fetch_version(ref: ref)).to eq(expected_version)
+      end
+    end
+
+
+    context 'when the version file is a gemspec' do
+      let(:config) do
+        Config.new(
+          client,
+          'action-testing.gemspec',
+          event_payload
+        )
+      end
+      let(:action) { Action.new(config) }
+      let(:file_path) { 'action-testing.gemspec' }
+      let(:content) do
+        %(
+        Gem::Specification.new do |s|
+          s.name                  = "action-testing"
+          s.required_ruby_version = "2.6.5"
+          s.version               = "#{expected_version}"
+        end
+      )
+      end
+
+      before do
+        allow(client).to receive(:contents)
+          .with(repo, path: file_path, query: { ref: ref })
+          .and_return('content' => decoded_content)
+      end
+
+      it 'returns the version' do
+        expect(action.fetch_version(ref: ref)).to eq(expected_version)
+      end
+    end
+
+    context 'when the version file is a package.json' do
+      let(:config) do
+        Config.new(
+          client,
+          'package.json',
+          event_payload
+        )
+      end
+      let(:action) { Action.new(config) }
+      let(:file_path) { 'package.json' }
+      let(:content) do
+        %(
+          {
+            "name": "action-testing",
+            "version": "#{expected_version}"
+          }
+        )
+      end
+
+      before do
+        allow(client).to receive(:contents)
+          .with(repo, path: file_path, query: { ref: ref })
+          .and_return('content' => decoded_content)
+      end
+
+      it 'returns the version' do
+        expect(action.fetch_version(ref: ref)).to eq(expected_version)
+      end
+    end
+
+    context 'when the version file is a pyproject.toml' do
+      let(:config) do
+        Config.new(
+          client,
+          'pyproject.toml',
+          event_payload
+        )
+      end
+      let(:action) { Action.new(config) }
+      let(:file_path) { 'pyproject.toml' }
+      let(:content) do
+        %(
+          [tool.poetry]
+          name = "action-testing"
+          version = "#{expected_version}"
+        )
+      end
+
+      before do
+        allow(client).to receive(:contents)
+          .with(repo, path: file_path, query: { ref: ref })
+          .and_return('content' => decoded_content)
+      end
+
       it 'returns the version' do
         expect(action.fetch_version(ref: ref)).to eq(expected_version)
       end
     end
 
     context 'when the version file does not exist' do
+      let(:config) do
+        Config.new(
+          client,
+          'version.rb',
+          event_payload
+        )
+      end
+      let(:action) { Action.new(config) }
+      let(:file_path) { 'version.rb' }
+      let(:content) { "module TestRepo\n  VERSION='#{expected_version}'\nend\n" }
+
       before do
         allow(client).to receive(:contents)
           .with(repo, path: file_path, query: { ref: ref })

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -31,6 +31,8 @@ describe Action do
     end
 
     it 'handles extended versioning' do
+      expect(Action::VERSION_SETTING).to match('VERSION=1.2.3.pre')
+      expect(Action::VERSION_SETTING).to match('VERSION=1.2.3.123456')
       expect(Action::VERSION_SETTING).to match('VERSION=1.2.3-alpha')
       expect(Action::VERSION_SETTING).to match('VERSION=1.2.3+build123')
     end

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -30,6 +30,10 @@ describe Action do
       expect(Action::VERSION_SETTING).to match('Version=1.2.3')
     end
 
+    it 'handles SB version.rb versioning using base and an algorithm' do
+      expect(Action::VERSION_SETTING).to match("base = '2.1.10'")
+    end
+
     it 'handles extended versioning' do
       expect(Action::VERSION_SETTING).to match('VERSION=1.2.3.pre')
       expect(Action::VERSION_SETTING).to match('VERSION=1.2.3.123456')


### PR DESCRIPTION
This pull request improves the testing of version-forget-me-not.

It changes the following:
- Combines fetch_version with fetch_version_safe as we only ever need to use the safe version
- Makes fetch_version public to test it
- Creates mocks of the supported version files to use in tests
- Tests the VERSION_SETTING regex
- Refactors the version_increased? tests because the names didn't reflect what they were testing and now we are testing fetch_version for all file types we don't need to do it again here

EDIT:

Have added a few more commits that should fix the error Greg identified.
SB repos do not have `version.rb` files that look like the ones in the tests. Instead they use `base = ....` and then set the version with a conditional. These files previously matched on a bare semver check because of the `base = ...`, but now the regex has been tightened up to look for a `version=...` setting, nothing matches. So, the solution is to look for `base =` as an alternative to `version=` 