### PR TITLE
handle double_underscored versioning in python

### DIFF
--- a/lib/action.rb
+++ b/lib/action.rb
@@ -8,7 +8,7 @@ class Action
 
   SEMVER = /["']*(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?["']*/ # rubocop:disable Layout/LineLength
   SEPARATOR = /\s*[:=]\s*/
-  VERSION_KEY = /(?:^|\.|\s|"|')(?:base|version)["']*/
+  VERSION_KEY = /(?:^_+|^|\.|\s|"|')(?:base|version)(?:["']*|_+)/
   VERSION_SETTING = Regexp.new(VERSION_KEY.source + SEPARATOR.source + SEMVER.source, Regexp::IGNORECASE).freeze
 
   def initialize(config)

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -58,6 +58,10 @@ describe Action do
       expect(Action::VERSION_SETTING).to match('gem.version = 1.2.3')
     end
 
+    it 'handles a lowercase, underscored, quote-marked, equal separated semver like in python' do
+      expect(Action::VERSION_SETTING).to match('__version__ = "1.0.0"')
+    end
+
     it 'does not match version number only' do
       expect(Action::VERSION_SETTING).not_to match('5.5.5')
     end


### PR DESCRIPTION
This allows double_underscored versioning (such as in python).